### PR TITLE
Import 5 canopy arrays and 3 photdiag arrays from AQM

### DIFF
--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -1295,8 +1295,12 @@ subroutine update_atmos_chemistry(state, rc)
 
   real(ESMF_KIND_R8), dimension(:,:,:,:), pointer :: q
 
+!IVAI: add coszens, jo3o1d, jno2, claie, cfch, cfrt, cclu, cpopu
   real(ESMF_KIND_R8), dimension(:,:), pointer :: aod, area, canopy, cmm,  &
-    dqsfc, dtsfc, fice, flake, focn, fsnow, hpbl, nswsfc, oro, psfc, &
+    claie, cfch, cfrt, cclu, cpopu, & !IVAI
+    dqsfc, dtsfc, fice, flake, focn, fsnow, hpbl, &
+    coszens, jo3o1d, jno2, &  !IVAI
+    nswsfc, oro, psfc, &
     q2m, rain, rainc, rca, shfsfc, slmsk, stype, swet, t2m, tsfc,    &
     u10m, uustar, v10m, vfrac, xlai, zorl
 
@@ -1323,6 +1327,42 @@ subroutine update_atmos_chemistry(state, rc)
         call cplFieldGet(state,'inst_tracer_diag_aod', farrayPtr2d=aod, rc=localrc)
         if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
           line=__LINE__, file=__FILE__, rcToReturn=rc)) return
+
+!IVAI: case ('import') canopy arrays read in via 'aqm_emiss_read'
+
+        call cplFieldGet(state,'inst_tracer_diag_claie', farrayPtr2d=claie, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, file=__FILE__, rcToReturn=rc)) return
+
+        call cplFieldGet(state,'inst_tracer_diag_cfch', farrayPtr2d=cfch, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, file=__FILE__, rcToReturn=rc)) return
+
+        call cplFieldGet(state,'inst_tracer_diag_cfrt', farrayPtr2d=cfrt, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, file=__FILE__, rcToReturn=rc)) return
+
+        call cplFieldGet(state,'inst_tracer_diag_cclu', farrayPtr2d=cclu, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, file=__FILE__, rcToReturn=rc)) return
+
+        call cplFieldGet(state,'inst_tracer_diag_cpopu', farrayPtr2d=cpopu, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, file=__FILE__, rcToReturn=rc)) return
+
+!IVAI: case ('import') photdiag arrays
+        call cplFieldGet(state,'inst_tracer_diag_coszens', farrayPtr2d=coszens, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, file=__FILE__, rcToReturn=rc)) return
+
+        call cplFieldGet(state,'inst_tracer_diag_jo3o1d', farrayPtr2d=jo3o1d, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, file=__FILE__, rcToReturn=rc)) return
+
+        call cplFieldGet(state,'inst_tracer_diag_jno2', farrayPtr2d=jno2, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, file=__FILE__, rcToReturn=rc)) return
+!IVAI
       end if
 
       !--- do not import tracer concentrations by default
@@ -1395,6 +1435,87 @@ subroutine update_atmos_chemistry(state, rc)
             GFS_Data(nb)%IntDiag%aod(ix) = aod(i,j)
           enddo
         enddo
+!IVAI: case ('import') canopy arrays read in via aqm_emiss_read
+        do j = 1, nj
+          jb = j + Atm_block%jsc - 1
+          do i = 1, ni
+            ib = i + Atm_block%isc - 1
+            nb = Atm_block%blkno(ib,jb)
+            ix = Atm_block%ixp(ib,jb)
+            GFS_Data(nb)%IntDiag%claie(ix) = claie(i,j)
+          enddo
+        enddo
+
+        do j = 1, nj
+          jb = j + Atm_block%jsc - 1
+          do i = 1, ni
+            ib = i + Atm_block%isc - 1
+            nb = Atm_block%blkno(ib,jb)
+            ix = Atm_block%ixp(ib,jb)
+            GFS_Data(nb)%IntDiag%cfch(ix) = cfch(i,j)
+          enddo
+        enddo
+
+        do j = 1, nj
+          jb = j + Atm_block%jsc - 1
+          do i = 1, ni
+            ib = i + Atm_block%isc - 1
+            nb = Atm_block%blkno(ib,jb)
+            ix = Atm_block%ixp(ib,jb)
+            GFS_Data(nb)%IntDiag%cfrt(ix) = cfrt(i,j)
+          enddo
+        enddo
+
+        do j = 1, nj
+          jb = j + Atm_block%jsc - 1
+          do i = 1, ni
+            ib = i + Atm_block%isc - 1
+            nb = Atm_block%blkno(ib,jb)
+            ix = Atm_block%ixp(ib,jb)
+            GFS_Data(nb)%IntDiag%cclu(ix) = cclu(i,j)
+          enddo
+        enddo
+
+        do j = 1, nj
+          jb = j + Atm_block%jsc - 1
+          do i = 1, ni
+            ib = i + Atm_block%isc - 1
+            nb = Atm_block%blkno(ib,jb)
+            ix = Atm_block%ixp(ib,jb)
+            GFS_Data(nb)%IntDiag%cpopu(ix) = cpopu(i,j)
+          enddo
+        enddo
+!IVAI: case ('import') photdiag arrays
+        do j = 1, nj
+          jb = j + Atm_block%jsc - 1
+          do i = 1, ni
+            ib = i + Atm_block%isc - 1
+            nb = Atm_block%blkno(ib,jb)
+            ix = Atm_block%ixp(ib,jb)
+            GFS_Data(nb)%IntDiag%coszens(ix) = coszens(i,j)
+          enddo
+        enddo
+
+        do j = 1, nj
+          jb = j + Atm_block%jsc - 1
+          do i = 1, ni
+            ib = i + Atm_block%isc - 1
+            nb = Atm_block%blkno(ib,jb)
+            ix = Atm_block%ixp(ib,jb)
+            GFS_Data(nb)%IntDiag%jo3o1d(ix) = jo3o1d(i,j)
+          enddo
+        enddo
+
+        do j = 1, nj
+          jb = j + Atm_block%jsc - 1
+          do i = 1, ni
+            ib = i + Atm_block%isc - 1
+            nb = Atm_block%blkno(ib,jb)
+            ix = Atm_block%ixp(ib,jb)
+            GFS_Data(nb)%IntDiag%jno2(ix) = jno2(i,j)
+          enddo
+        enddo
+!IVAI
       end if
 
       if (GFS_control%debug) then
@@ -1403,6 +1524,33 @@ subroutine update_atmos_chemistry(state, rc)
         if (GFS_control%cplaqm) &
           write(6,'("update_atmos: ",a,": aod  - min/max    ",3g16.6)') &
             trim(state), minval(aod), maxval(aod)
+!IVAI: case ('import') canopy arrays read via aqm_emiss_read
+        if (GFS_control%cplaqm) &
+          write(6,'("update_atmos: ",a,": claie - min/max    ",3g16.6)') &
+            trim(state), minval(claie), maxval(claie)
+        if (GFS_control%cplaqm) &
+          write(6,'("update_atmos: ",a,": cfch  - min/max    ",3g16.6)') &
+            trim(state), minval(cfch), maxval(cfch)
+        if (GFS_control%cplaqm) &
+          write(6,'("update_atmos: ",a,": cfrt  - min/max    ",3g16.6)') &
+            trim(state), minval(cfrt), maxval(cfrt)
+        if (GFS_control%cplaqm) &
+          write(6,'("update_atmos: ",a,": cclu  - min/max    ",3g16.6)') &
+            trim(state), minval(cclu), maxval(cclu)
+        if (GFS_control%cplaqm) &
+          write(6,'("update_atmos: ",a,": cpopu - min/max    ",3g16.6)') &
+            trim(state), minval(cpopu), maxval(cpopu)
+!IVAI: case ('import') photdiag arrays
+        if (GFS_control%cplaqm) &
+          write(6,'("update_atmos: ",a,": coszens - min/max    ",3g16.6)') &
+            trim(state), minval(coszens), maxval(coszens)
+        if (GFS_control%cplaqm) &
+          write(6,'("update_atmos: ",a,": jo3o1d  - min/max    ",3g16.6)') &
+            trim(state), minval(jo3o1d), maxval(jo3o1d)
+        if (GFS_control%cplaqm) &
+          write(6,'("update_atmos: ",a,": jno2    - min/max    ",3g16.6)') &
+            trim(state), minval(jno2), maxval(jno2)
+!IVAI
       end if
 
     case ('export')

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -1201,8 +1201,8 @@ module GFS_typedefs
 
     real(kind=kind_phys) :: rbcr            !< Critical Richardson Number in the PBL scheme
     real(kind=kind_phys) :: betascu         !< Tuning parameter for prog. closure shallow clouds
-    real(kind=kind_phys) :: betamcu         !< Tuning parameter for prog. closure midlevel clouds 
-    real(kind=kind_phys) :: betadcu         !< Tuning parameter for prog. closure deep clouds 
+    real(kind=kind_phys) :: betamcu         !< Tuning parameter for prog. closure midlevel clouds
+    real(kind=kind_phys) :: betadcu         !< Tuning parameter for prog. closure deep clouds
 
     !--- MYNN parameters/switches
     logical              :: do_mynnedmf
@@ -1578,7 +1578,7 @@ module GFS_typedefs
     real(kind=kind_phys) :: huge            !< huge fill value
 
 !--- AQM Canopy
-    logical              :: do_canopy       !< control flag for aqm canopy effects 
+    logical              :: do_canopy       !< control flag for aqm canopy effects
 !--- lightning threat and diagsnostics
     logical              :: lightning_threat !< report lightning threat indices
 
@@ -2110,6 +2110,19 @@ module GFS_typedefs
 
     ! Diagnostics for coupled air quality model
     real (kind=kind_phys), pointer :: aod   (:)   => null()    !< instantaneous aerosol optical depth ( n/a )
+
+!IVAI
+    ! Diagnostics for coupled air quality model
+    real (kind=kind_phys), pointer :: claie(:)    => null()    ! Leaf Area Index ECCC
+    real (kind=kind_phys), pointer :: cfch (:)    => null()    ! Forest Canopy Height
+    real (kind=kind_phys), pointer :: cfrt (:)    => null()    ! Forest Fraction
+    real (kind=kind_phys), pointer :: cclu (:)    => null()    ! Clumping Index
+    real (kind=kind_phys), pointer :: cpopu(:)    => null()    ! Population density
+
+    real (kind=kind_phys), pointer :: coszens(:)  => null()    ! Cosine SZA for photolysis
+    real (kind=kind_phys), pointer :: jo3o1d(:)   => null()    ! instantaneous O3O1D photolysis rate
+    real (kind=kind_phys), pointer :: jno2  (:)   => null()    ! instantaneous NO2   photolysis rate
+!IVAI
 
     ! Auxiliary output arrays for debugging
     real (kind=kind_phys), pointer :: aux2d(:,:)  => null()    !< auxiliary 2d arrays in output (for debugging)
@@ -3912,10 +3925,10 @@ module GFS_typedefs
     real(kind=kind_phys) :: radar_tten_limits(2) = (/ limit_unspecified, limit_unspecified /)
     integer :: itime
     integer :: w3kindreal,w3kindint
-   
+
 !--- switch for aqm canopy effects
     logical :: do_canopy       = .false.         !< flag for canopy option
- 
+
 !--- END NAMELIST VARIABLES
 
     NAMELIST /gfs_physics_nml/                                                              &
@@ -4064,7 +4077,7 @@ module GFS_typedefs
                           !--- (DFI) time ranges with radar-prescribed microphysics tendencies
                           !          and (maybe) convection suppression
                                fh_dfi_radar, radar_tten_limits, do_cap_suppress,            &
-                          !    aqm canopy option 
+                          !    aqm canopy option
                                do_canopy,                                                   &
                           !--- GSL lightning threat indices
                                lightning_threat
@@ -4808,7 +4821,7 @@ module GFS_typedefs
     Model%hwrf_samfdeep = hwrf_samfdeep
     Model%hwrf_samfshal = hwrf_samfshal
 
-    !--prognostic closure - moisture coupling                                                                                 
+    !--prognostic closure - moisture coupling
     if ((progsigma .and. imfdeepcnv/=2) .and. (progsigma .and. imfdeepcnv/=5)) then
        write(*,*) 'Logic error: progsigma requires imfdeepcnv=2 or 5'
        stop
@@ -5497,9 +5510,9 @@ module GFS_typedefs
           write(*,*) 'NSSL micro: CCN is ON'
         ENDIF
       ENDIF
-      
+
       ! add checks for nssl_3moment
-      IF ( ( Model%nssl_3moment ) ) THEN 
+      IF ( ( Model%nssl_3moment ) ) THEN
         IF ( Model%ntrz < 1 ) THEN
           write(*,*) 'NSSL micro: 3-moment is ON, but rain_ref tracer is missing'
           stop
@@ -7863,6 +7876,40 @@ module GFS_typedefs
       allocate (Diag%aod(IM))
       Diag%aod = zero
     end if
+
+!IVAI:
+    ! Air quality diagnostics
+    ! -- initialize diagnostic variables
+    if (Model%cplaqm) then
+
+!IVAI: canopy arrays read via aqm_emis_read
+      allocate (Diag%claie(IM))
+      Diag%claie = zero
+
+      allocate (Diag%cfch  (IM))
+      Diag%cfch   = zero
+
+      allocate (Diag%cfrt  (IM))
+      Diag%cfrt   = zero
+
+      allocate (Diag%cclu  (IM))
+      Diag%cclu   = zero
+
+      allocate (Diag%cpopu (IM))
+      Diag%cpopu  = zero
+
+!IVAI: photdiag arrays
+      allocate (Diag%coszens(IM))
+      Diag%coszens= zero
+
+      allocate (Diag%jo3o1d(IM))
+      Diag%jo3o1d = zero
+
+      allocate (Diag%jno2(IM))
+      Diag%jno2 = zero
+
+    end if
+!IVAI
 
     ! Auxiliary arrays in output for debugging
     if (Model%naux2d>0) then

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -1639,6 +1639,43 @@
   type = real
   kind = kind_phys
   active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
+### IVAI
+[claie]
+  standard_name = canopy_leaf_area_index
+  long_name = canopy leaf area index
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+[cfch]
+  standard_name = canopy_forest_height
+  long_name = canopy forest height
+  units = m
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+[cfrt]
+  standard_name = canopy_forest_fraction
+  long_name = canopy forest fraction
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+[cclu]
+  standard_name = canopy_clumping_index
+  long_name = canopy clumping index
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+[cpopu]
+  standard_name = canopy_population_density
+  long_name = population density used for canopy correction
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+### IVAI
 [canopylaixy]
   standard_name = canopy_leaf_area_index
   long_name = canopy leaf area index

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -1676,38 +1676,38 @@
   type = real
   kind = kind_phys
 ### IVAI
-[canopylaixy]
-  standard_name = canopy_leaf_area_index
-  long_name = canopy leaf area index
-  units = none
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  active = (control_for_land_surface_scheme == identifier_for_noah_land_surface_scheme .or. control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme .or. (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme .and. flag_for_reading_canopy_leaf_area_index_from_input))
-[canopyfchxy]
-  standard_name = canopy_forest_height
-  long_name = canopy forest height
-  units = m
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  active = (control_for_land_surface_scheme == identifier_for_noah_land_surface_scheme .or. control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme .or. (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme .and. flag_for_reading_canopy_forest_height_from_input))
-[canopyfrtxy]
-  standard_name = canopy_forest_fraction
-  long_name = canopy forest fraction
-  units = none
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  active = (control_for_land_surface_scheme == identifier_for_noah_land_surface_scheme .or. control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme .or. (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme .and. flag_for_reading_canopy_forest_fraction_from_input))
-[canopycluxy]
-  standard_name = canopy_clumping_index
-  long_name = canopy clumping index
-  units = none
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  active = (control_for_land_surface_scheme == identifier_for_noah_land_surface_scheme .or. control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme .or. (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme .and. flag_for_reading_canopy_clumping_index_from_input))
+#[canopylaixy]
+#  standard_name = canopy_leaf_area_index
+#  long_name = canopy leaf area index
+#  units = none
+#  dimensions = (horizontal_loop_extent)
+#  type = real
+#  kind = kind_phys
+#  active = (control_for_land_surface_scheme == identifier_for_noah_land_surface_scheme .or. control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme .or. (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme .and. flag_for_reading_canopy_leaf_area_index_from_input))
+#[canopyfchxy]
+#  standard_name = canopy_forest_height
+#  long_name = canopy forest height
+#  units = m
+#  dimensions = (horizontal_loop_extent)
+#  type = real
+#  kind = kind_phys
+#  active = (control_for_land_surface_scheme == identifier_for_noah_land_surface_scheme .or. control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme .or. (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme .and. flag_for_reading_canopy_forest_height_from_input))
+#[canopyfrtxy]
+#  standard_name = canopy_forest_fraction
+#  long_name = canopy forest fraction
+#  units = none
+#  dimensions = (horizontal_loop_extent)
+#  type = real
+#  kind = kind_phys
+#  active = (control_for_land_surface_scheme == identifier_for_noah_land_surface_scheme .or. control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme .or. (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme .and. flag_for_reading_canopy_forest_fraction_from_input))
+#[canopycluxy]
+#  standard_name = canopy_clumping_index
+#  long_name = canopy clumping index
+#  units = none
+#  dimensions = (horizontal_loop_extent)
+#  type = real
+#  kind = kind_phys
+#  active = (control_for_land_surface_scheme == identifier_for_noah_land_surface_scheme .or. control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme .or. (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme .and. flag_for_reading_canopy_clumping_index_from_input))
 [taussxy]
   standard_name = dimensionless_age_of_surface_snow
   long_name = non-dimensional snow age

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -1,11 +1,11 @@
 module GFS_diagnostics
 
 !-----------------------------------------------------------------------
-!    GFS_diagnostics_mod defines a data type and contains the routine 
+!    GFS_diagnostics_mod defines a data type and contains the routine
 !    to populate said type with diagnostics from the GFS physics for
 !    use by the modeling system for output
 !-----------------------------------------------------------------------
- 
+
   use machine,            only: kind_phys
 
   !--- GFS_typedefs ---
@@ -51,7 +51,7 @@ module GFS_diagnostics
   CONTAINS
 
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    
+
  ! Helper function for GFS_externaldiag_populate to handle the massive dtend(:,:,dtidx(:,:)) array
     subroutine add_dtend(Model,ExtDiag,IntDiag,idx,nblks,itrac,iprocess,desc,unit)
     implicit none
@@ -62,7 +62,7 @@ module GFS_diagnostics
     integer, intent(inout) :: idx
     real(kind=kind_phys), pointer :: dtend(:,:,:) ! Assumption: dtend is null iff all(dtidx <= 1)
     character(len=*), intent(in), optional :: desc, unit
-    
+
     integer :: idtend, nb
 
     idtend = Model%dtidx(itrac,iprocess)
@@ -88,17 +88,17 @@ module GFS_diagnostics
        enddo
     endif
   end subroutine add_dtend
-  
-!-------------------------------------------------------------------------      
+
+!-------------------------------------------------------------------------
 !--- GFS_externaldiag_populate ---
-!-------------------------------------------------------------------------      
-!    creates and populates a data type with GFS physics diagnostic 
+!-------------------------------------------------------------------------
+!    creates and populates a data type with GFS physics diagnostic
 !    variables which is then handed off to the IPD for use by the model
-!    infrastructure layer to output as needed.  The data type includes 
-!    names, units, conversion factors, etc.  There is no copying of data, 
-!    but instead pointers are associated to the internal representation 
+!    infrastructure layer to output as needed.  The data type includes
+!    names, units, conversion factors, etc.  There is no copying of data,
+!    but instead pointers are associated to the internal representation
 !    of each individual physics diagnostic.
-!-------------------------------------------------------------------------      
+!-------------------------------------------------------------------------
   subroutine GFS_externaldiag_populate (ExtDiag, Model, Statein, Stateout, Sfcprop, Coupling,  &
                                         Grid, Tbd, Cldprop, Radtend, IntDiag, Init_parm)
 !---------------------------------------------------------------------------------------------!
@@ -158,7 +158,7 @@ module GFS_diagnostics
     ExtDiag(:)%name = ''
     ExtDiag(:)%intpl_method = 'nearest_stod'
 
-    idx = 0 
+    idx = 0
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -945,11 +945,132 @@ module GFS_diagnostics
     endif
   endif
 
+!IVAI
+!--- air quality diagnostics ---
+  if (Model%cplaqm) then
+
+!IVAI: canopy arrays read via aqm_emis_read
+    if (associated(IntDiag(1)%claie)) then
+!      print*, 'GFS_diagnostics: claie ', IntDiag(1)%claie
+      idx = idx + 1
+      ExtDiag(idx)%axes = 2
+      ExtDiag(idx)%name = 'CLAIE'
+      ExtDiag(idx)%desc = 'Leaf Area Index ECCC'
+      ExtDiag(idx)%unit = 'numerical'
+      ExtDiag(idx)%mod_name = 'gfs_phys'
+      allocate (ExtDiag(idx)%data(nblks))
+      do nb = 1,nblks
+        ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%claie
+      enddo
+    endif
+
+    if (associated(IntDiag(1)%cfch)) then
+!      print*, 'GFS_diagnostics: cfch   ', IntDiag(1)%cfch
+      idx = idx + 1
+      ExtDiag(idx)%axes = 2
+      ExtDiag(idx)%name = 'CFCH'
+      ExtDiag(idx)%desc = 'Forest Canopy Height'
+      ExtDiag(idx)%unit = 'numerical'
+      ExtDiag(idx)%mod_name = 'gfs_phys'
+      allocate (ExtDiag(idx)%data(nblks))
+      do nb = 1,nblks
+        ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%cfch
+      enddo
+    endif
+
+    if (associated(IntDiag(1)%cfrt)) then
+!      print*, 'GFS_diagnostics: cfrt ', IntDiag(1)%cfrt
+      idx = idx + 1
+      ExtDiag(idx)%axes = 2
+      ExtDiag(idx)%name = 'CFRT'
+      ExtDiag(idx)%desc = 'Forest Canopy Fraction'
+      ExtDiag(idx)%unit = 'numerical'
+      ExtDiag(idx)%mod_name = 'gfs_phys'
+      allocate (ExtDiag(idx)%data(nblks))
+      do nb = 1,nblks
+        ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%cfrt
+      enddo
+    endif
+
+    if (associated(IntDiag(1)%cclu)) then
+!      print*, 'GFS_diagnostics: cclu ', IntDiag(1)%cclu
+      idx = idx + 1
+      ExtDiag(idx)%axes = 2
+      ExtDiag(idx)%name = 'CCLU'
+      ExtDiag(idx)%desc = 'Canopy Clumping Index'
+      ExtDiag(idx)%unit = 'numerical'
+      ExtDiag(idx)%mod_name = 'gfs_phys'
+      allocate (ExtDiag(idx)%data(nblks))
+      do nb = 1,nblks
+        ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%cclu
+      enddo
+    endif
+
+    if (associated(IntDiag(1)%cpopu)) then
+      print*, 'GFS_diagnostics: cpopu ', IntDiag(1)%cpopu
+      idx = idx + 1
+      ExtDiag(idx)%axes = 2
+      ExtDiag(idx)%name = 'CPOPU'
+      ExtDiag(idx)%desc = 'Population Density for canopy correction'
+      ExtDiag(idx)%unit = 'numerical'
+      ExtDiag(idx)%mod_name = 'gfs_phys'
+      allocate (ExtDiag(idx)%data(nblks))
+      do nb = 1,nblks
+        ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%cpopu
+      enddo
+    endif
+
+! IVAI: photdiag fields
+    if (associated(IntDiag(1)%coszens)) then
+!      print*, 'GFS_diagnostics: coszens ', IntDiag(1)%coszens
+      idx = idx + 1
+      ExtDiag(idx)%axes = 2
+      ExtDiag(idx)%name = 'COSZENS'
+      ExtDiag(idx)%desc = 'Cosine Solar Zenith Angle for Photolysis'
+      ExtDiag(idx)%unit = 'numerical'
+      ExtDiag(idx)%mod_name = 'gfs_phys'
+      allocate (ExtDiag(idx)%data(nblks))
+      do nb = 1,nblks
+        ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%coszens
+      enddo
+    endif
+
+    if (associated(IntDiag(1)%jo3o1d)) then
+!      print*, 'GFS_diagnostics: jo3o1d ', IntDiag(1)%jo3o1d
+      idx = idx + 1
+      ExtDiag(idx)%axes = 2
+      ExtDiag(idx)%name = 'JO3O1D'
+      ExtDiag(idx)%desc = 'photolysis rate O3 for canopy correction'
+      ExtDiag(idx)%unit = 'numerical'
+      ExtDiag(idx)%mod_name = 'gfs_phys'
+      allocate (ExtDiag(idx)%data(nblks))
+      do nb = 1,nblks
+        ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%jo3o1d
+      enddo
+    endif
+
+    if (associated(IntDiag(1)%jno2)) then
+!      print*, 'GFS_diagnostics: jno2 ', IntDiag(1)%jno2
+      idx = idx + 1
+      ExtDiag(idx)%axes = 2
+      ExtDiag(idx)%name = 'JNO2'
+      ExtDiag(idx)%desc = 'photolysis rate NO2 for canopy correction'
+      ExtDiag(idx)%unit = 'numerical'
+      ExtDiag(idx)%mod_name = 'gfs_phys'
+      allocate (ExtDiag(idx)%data(nblks))
+      do nb = 1,nblks
+        ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%jno2
+      enddo
+    endif
+
+  endif
+!IVAI
+
 !
 !
 !--- accumulated diagnostics ---
     do num = 1,NFXR
-      write (xtra,'(I2.2)') num 
+      write (xtra,'(I2.2)') num
       idx = idx + 1
       ExtDiag(idx)%axes = 2
       ExtDiag(idx)%name = 'fluxr_'//trim(xtra)
@@ -965,7 +1086,7 @@ module GFS_diagnostics
 !--- the next two appear to be appear to be coupling fields in gloopr
 !--- each has four elements
 !rab    do num = 1,4
-!rab      write (xtra,'(I1)') num 
+!rab      write (xtra,'(I1)') num
 !rab      idx = idx + 1
 !rab      ExtDiag(idx)%axes = 2
 !rab      ExtDiag(idx)%name = 'dswcmp_'//trim(xtra)
@@ -978,7 +1099,7 @@ module GFS_diagnostics
 !rab    enddo
 !rab
 !rab    do num = 1,4
-!rab      write (xtra,'(I1)') num 
+!rab      write (xtra,'(I1)') num
 !rab      idx = idx + 1
 !rab      ExtDiag(idx)%axes = 2
 !rab      ExtDiag(idx)%name = 'uswcmp_'//trim(xtra)
@@ -1103,7 +1224,7 @@ module GFS_diagnostics
     do nb = 1,nblks
       ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%snohfa(:)
     enddo
-    
+
     if (Model%lsm == Model%lsm_noahmp) then
      idx = idx + 1
      ExtDiag(idx)%axes = 2
@@ -1383,7 +1504,7 @@ module GFS_diagnostics
       ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%tedir(:)
     enddo
 
-    if (Model%lsm == Model%lsm_noahmp) then   
+    if (Model%lsm == Model%lsm_noahmp) then
      idx = idx + 1
      ExtDiag(idx)%axes = 2
      ExtDiag(idx)%name = 'wa_acc'
@@ -2175,7 +2296,7 @@ module GFS_diagnostics
       ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%gfluxi(:)
     enddo
 
-    if (Model%lsm == Model%lsm_noahmp) then   
+    if (Model%lsm == Model%lsm_noahmp) then
      idx = idx + 1
      ExtDiag(idx)%axes = 2
      ExtDiag(idx)%name = 'pahi'
@@ -2457,7 +2578,7 @@ module GFS_diagnostics
         ExtDiag(idx)%data(nb)%var3 => Coupling(nb)%spp_wts_pbl(:,:)
       enddo
     endif
-    
+
     if (Model%do_spp) then
       idx = idx + 1
       ExtDiag(idx)%axes = 3
@@ -2470,7 +2591,7 @@ module GFS_diagnostics
         ExtDiag(idx)%data(nb)%var3 => Coupling(nb)%spp_wts_sfc(:,:)
       enddo
     endif
-    
+
     if (Model%do_spp) then
       idx = idx + 1
       ExtDiag(idx)%axes = 3
@@ -2483,7 +2604,7 @@ module GFS_diagnostics
         ExtDiag(idx)%data(nb)%var3 => Coupling(nb)%spp_wts_mp(:,:)
       enddo
     endif
-    
+
     if (Model%do_spp) then
       idx = idx + 1
       ExtDiag(idx)%axes = 3
@@ -2496,7 +2617,7 @@ module GFS_diagnostics
         ExtDiag(idx)%data(nb)%var3 => Coupling(nb)%spp_wts_gwd(:,:)
       enddo
     endif
-    
+
     if (Model%do_spp) then
       idx = idx + 1
       ExtDiag(idx)%axes = 3
@@ -2666,7 +2787,7 @@ module GFS_diagnostics
       do nb = 1,nblks
         ExtDiag(idx)%data(nb)%int2 => Sfcprop(nb)%use_lake_model(:)
       enddo
-    
+
       if(Model%iopt_lake==Model%iopt_lake_clm) then
 
         ! Populate the 3D arrays separately since the code is complicated:
@@ -2693,7 +2814,7 @@ module GFS_diagnostics
         do nb = 1,nblks
            ExtDiag(idx)%data(nb)%int2 => Sfcprop(nb)%lake_cannot_freeze(:)
         enddo
-        
+
         idx = idx + 1
         ExtDiag(idx)%axes = 2
         ExtDiag(idx)%name = 'lake_t2m'
@@ -2801,7 +2922,7 @@ module GFS_diagnostics
         do nb = 1,nblks
           ExtDiag(idx)%data(nb)%var2 => Sfcprop(nb)%lake_ht(:)
         enddo
-        
+
       endif
 
   endif
@@ -2898,8 +3019,8 @@ module GFS_diagnostics
     do nb = 1,nblks
       ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%du3dt_pbl(:,:)
     enddo
-!    
-! dv3dt_pbl     
+!
+! dv3dt_pbl
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'dv3dt_pbl_ugwp'
@@ -2910,8 +3031,8 @@ module GFS_diagnostics
     do nb = 1,nblks
       ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dv3dt_pbl(:,:)
     enddo
-!    
-! dt3dt_pbl     
+!
+! dt3dt_pbl
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'dt3dt_pbl_ugwp'
@@ -2923,8 +3044,8 @@ module GFS_diagnostics
       ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dt3dt_pbl(:,:)
     enddo
 !
-! uav_ugwp 
-! 
+! uav_ugwp
+!
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'uav_ugwp'
@@ -2936,8 +3057,8 @@ module GFS_diagnostics
       ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%uav_ugwp(:,:)
     enddo
 !
-! tav_ugwp 
-! 
+! tav_ugwp
+!
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'tav_ugwp'
@@ -2971,7 +3092,7 @@ module GFS_diagnostics
       ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%du3dt_ngw(:,:)
     enddo
 !
-!    
+!
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'du3dt_mtb'
@@ -3443,7 +3564,7 @@ module GFS_diagnostics
           endif
         enddo
       enddo
-      
+
       if_qdiag3d: if(Model%qdiag3d) then
 
         idx = idx + 1
@@ -3488,7 +3609,7 @@ module GFS_diagnostics
 
 !rab
 !rab    do num = 1,5+Mdl_parms%pl_coeff
-!rab      write (xtra,'(I1)') num 
+!rab      write (xtra,'(I1)') num
 !rab      idx = idx + 1
 !rab      ExtDiag(idx)%axes = 3
 !rab      ExtDiag(idx)%name = 'dtend_'//trim(xtra)
@@ -3854,7 +3975,7 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'scolor'
-    ExtDiag(idx)%desc = 'soil color in integer 1-20' 
+    ExtDiag(idx)%desc = 'soil color in integer 1-20'
     ExtDiag(idx)%unit = 'number'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     allocate (ExtDiag(idx)%data(nblks))
@@ -5181,7 +5302,7 @@ module GFS_diagnostics
     character(:), allocatable :: fullname
 
     integer :: nk, idx0, iblk
-    
+
     do iblk=1,nblks
       call link_all_levels(Sfcprop(iblk)%lake_snow_z3d, 'lake_snow_z3d', 'lake snow level depth', 'm')
     enddo
@@ -5309,6 +5430,6 @@ module GFS_diagnostics
      !
   end function soil_layer_depth
 
-!-------------------------------------------------------------------------      
+!-------------------------------------------------------------------------
 
 end module GFS_diagnostics

--- a/cpl/module_cplfields.F90
+++ b/cpl/module_cplfields.F90
@@ -158,7 +158,7 @@ module module_cplfields
     FieldInfo("t2m                                      ", "s") ]
 
 ! Import Fields ----------------------------------------
-  integer,          public, parameter :: NimportFields = 48
+  integer,          public, parameter :: NimportFields = 48 + 3 + 5 !IVAI: add 3 inst_tracer_diag
   logical,          public            :: importFieldsValid(NimportFields)
   type(ESMF_Field), target, public    :: importFields(NimportFields)
 
@@ -181,6 +181,17 @@ module module_cplfields
     FieldInfo("inst_ice_vis_dir_albedo                  ", "s"), &
     FieldInfo("wave_z0_roughness_length                 ", "s"), &
     FieldInfo("inst_tracer_diag_aod                     ", "s"), &
+!IVAI: import canopy fields from AQM component
+    FieldInfo("inst_tracer_diag_claie                   ", "s"), &
+    FieldInfo("inst_tracer_diag_cfch                    ", "s"), &
+    FieldInfo("inst_tracer_diag_cfrt                    ", "s"), &
+    FieldInfo("inst_tracer_diag_cclu                    ", "s"), &
+    FieldInfo("inst_tracer_diag_cpopu                   ", "s"), &
+!IVAI: import photolysis diagnostics from AQM component
+    FieldInfo("inst_tracer_diag_coszens                 ", "s"), &
+    FieldInfo("inst_tracer_diag_jo3o1d                  ", "s"), &
+    FieldInfo("inst_tracer_diag_jno2                    ", "s"), &
+!IVAI
 
     ! For receiving fluxes from mediator
     FieldInfo("stress_on_air_ocn_zonal                  ", "s"), &


### PR DESCRIPTION
## Description

(Instructions: this, and all subsequent sections of text should be removed and filled in as appropriate.)
Provide a detailed description of what this PR does.  
What bug does it fix, or what feature does it add?  
Is a change of answers expected from this PR?  

Import 5 canopy arrays and 3 photdiag output arrays from AQM

### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #<issue_number>
- fixes noaa-emc/fv3atm/issues/<issue_number>

Consistent use of canopy data in photolysis and diffusion, formerly diffusion using LSM Noah look-up table. Enable 2D photolysis diagnostics.

## Testing

How were these changes tested?  
Tested on rdhpcs hera.

What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) 
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch

The use the AQM canopy data in diffusion changes the results when 'do_canopy' correction is selected.

## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

feature/aqm_canopy

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>
